### PR TITLE
4.3

### DIFF
--- a/CRAN-RELEASE
+++ b/CRAN-RELEASE
@@ -1,2 +1,0 @@
-This package was submitted to CRAN on 2021-08-18.
-Once it is accepted, delete this file and tag the release (commit 429b797).

--- a/CRAN-RELEASE
+++ b/CRAN-RELEASE
@@ -1,0 +1,2 @@
+This package was submitted to CRAN on 2021-08-18.
+Once it is accepted, delete this file and tag the release (commit 429b797).

--- a/R/make_xifti_components.R
+++ b/R/make_xifti_components.R
@@ -85,7 +85,7 @@ make_cortex <- function(
       cortex <- file.path(
         tempdir(), 
         # [TO DO] more elegant naming?
-        gsub("\\.gii$", ".selected_idx\\.func\\.gii", basename(cortex_original))
+        gsub("\\.gii$", "\\.selected_idx\\.func\\.gii", basename(cortex_original))
       )
       
       run_wb_cmd(paste(

--- a/R/make_xifti_components.R
+++ b/R/make_xifti_components.R
@@ -82,11 +82,25 @@ make_cortex <- function(
         idx_string <- paste("-column", paste(idx, collapse=" -column "))
       }
       cortex_original <- cortex
-      cortex <- file.path(
-        tempdir(), 
-        # [TO DO] more elegant naming?
-        gsub("\\.gii$", "\\.selected_idx\\.func\\.gii", basename(cortex_original))
-      )
+
+      # Name for new GIFTI file
+      if (endsWith(cortex, ".func.gii")) {
+        cortex <- file.path(
+          tempdir(), 
+          gsub("\\.func\\.gii$", "\\.sel_idx\\.func\\.gii", basename(cortex_original))
+        )
+      } else if (endsWith(cortex, ".label.gii")) {
+        cortex <- file.path(
+          tempdir(), 
+          gsub("\\.label\\.gii$", "\\.sel_idx\\.label\\.gii", basename(cortex_original))
+        )
+      } else {
+        # Guess func.
+        # [TO DO] warn user?
+        cortex <- file.path(
+          tempdir(), paste0(basename(cortex_original), ".func.gii")
+        ) 
+      }
       
       run_wb_cmd(paste(
         "-metric-merge", cortex, "-metric", cortex_original, idx_string

--- a/R/read_cifti_flat.R
+++ b/R/read_cifti_flat.R
@@ -40,18 +40,18 @@ read_cifti_flat <- function(
     stop("`", cifti_fname, "` is not an existing file.") 
   }
   
-  # Get the components of the CIFTI file path.
+  # Get the components of the CIFTI and GIFTI file paths.
   bname_cifti <- basename(cifti_fname)
   extn_cii <- get_cifti_extn(bname_cifti)
   extn_cii <- paste0(".", extn_cii) # e.g. ".dtseries.nii"
   is_label = FALSE# extn_cii == ".dlabel.nii"
+  extn_gii <- ifelse(is_label, ".label.gii", ".func.gii")
+  extn_gii2 <- gsub(".", "\\.", extn_gii, fixed=TRUE)
+  extn_cii2 <- paste0(gsub(".", "\\.", extn_cii, fixed=TRUE), "$")
 
   # If gifti_fname is not provided, use the CIFTI_fname but replace the 
   #   extension with "flat.gii".
   if (is.null(gifti_fname)) {
-    extn_gii <- ifelse(is_label, ".label.gii", ".func.gii")
-    extn_gii2 <- gsub(".", "\\.", extn_gii, fixed=TRUE)
-    extn_cii2 <- paste0(gsub(".", "\\.", extn_cii, fixed=TRUE), "$")
     if (grepl(bname_cifti, extn_cii2)) {
       gifti_fname <- gsub(extn_cii2, extn_gii2, bname_cifti)
     } else {

--- a/R/read_cifti_flat.R
+++ b/R/read_cifti_flat.R
@@ -44,7 +44,7 @@ read_cifti_flat <- function(
   bname_cifti <- basename(cifti_fname)
   extn_cii <- get_cifti_extn(bname_cifti)
   extn_cii <- paste0(".", extn_cii) # e.g. ".dtseries.nii"
-  is_label = extn_cii == ".dlabel.nii"
+  is_label = FALSE# extn_cii == ".dlabel.nii"
 
   # If gifti_fname is not provided, use the CIFTI_fname but replace the 
   #   extension with "flat.gii".

--- a/R/read_cifti_flat.R
+++ b/R/read_cifti_flat.R
@@ -14,7 +14,8 @@
 #'  and then reading it in. Should the GIFTI file be kept? If \code{FALSE}
 #'  (default), write it in a temporary directory regardless of \code{write_dir}.
 #' @param gifti_fname File path of GIFTI-format data to save the CIFTI as. 
-#'  Default: the CIFTI_fname but with the extension replaced with "flat.gii".
+#'  Should end with ".func.gii". Default: the CIFTI_fname but with the extension
+#'  replaced with ".func.gii".
 #' @inheritParams idx_Param
 #' @param write_dir The directory in which to save the GIFTI, if it is being 
 #'  kept. If \code{NULL} (default), use the current working directory.
@@ -41,12 +42,17 @@ read_cifti_flat <- function(
   
   # Get the components of the CIFTI file path.
   bname_cifti <- basename(cifti_fname)
-  extn_cifti <- get_cifti_extn(bname_cifti)  # "dtseries.nii" or "dscalar.nii"
+  extn_cifti <- get_cifti_extn(bname_cifti)
+  extn_cifti <- paste0(".", extn_cifti) # e.g. ".dtseries.nii"
 
   # If gifti_fname is not provided, use the CIFTI_fname but replace the 
   #   extension with "flat.gii".
   if (is.null(gifti_fname)) {
-    gifti_fname <- gsub(extn_cifti, "flat.gii", bname_cifti, fixed=TRUE)
+    if (endsWith(bname_cifti, extn_cifti)) {
+      gifti_fname <- gsub(extn_cifti, ".func.gii", bname_cifti, fixed=TRUE)
+    } else {
+      gifti_fname <- paste0(bname_cifti, ".func.gii")
+    }
   }
   if (!keep) { write_dir <- tempdir() }
   gifti_fname <- format_path(gifti_fname, write_dir, mode=2)
@@ -74,7 +80,7 @@ read_cifti_flat <- function(
     gifti_fname_original <- gifti_fname
     gifti_fname <- file.path(
       tempdir(), 
-      gsub("\\.gii$", ".selected_idx\\.gii", basename(gifti_fname_original))
+      gsub("func\\.gii$", "selected_idx\\.func\\.gii", basename(gifti_fname_original))
     )
 
     run_wb_cmd(paste(

--- a/R/read_cifti_flat.R
+++ b/R/read_cifti_flat.R
@@ -42,16 +42,20 @@ read_cifti_flat <- function(
   
   # Get the components of the CIFTI file path.
   bname_cifti <- basename(cifti_fname)
-  extn_cifti <- get_cifti_extn(bname_cifti)
-  extn_cifti <- paste0(".", extn_cifti) # e.g. ".dtseries.nii"
+  extn_cii <- get_cifti_extn(bname_cifti)
+  extn_cii <- paste0(".", extn_cii) # e.g. ".dtseries.nii"
+  is_label = extn_cii == ".dlabel.nii"
 
   # If gifti_fname is not provided, use the CIFTI_fname but replace the 
   #   extension with "flat.gii".
   if (is.null(gifti_fname)) {
-    if (endsWith(bname_cifti, extn_cifti)) {
-      gifti_fname <- gsub(extn_cifti, ".func.gii", bname_cifti, fixed=TRUE)
+    extn_gii <- ifelse(is_label, ".label.gii", ".func.gii")
+    extn_gii2 <- gsub(".", "\\.", extn_gii, fixed=TRUE)
+    extn_cii2 <- paste0(gsub(".", "\\.", extn_cii, fixed=TRUE), "$")
+    if (grepl(bname_cifti, extn_cii2)) {
+      gifti_fname <- gsub(extn_cii2, extn_gii2, bname_cifti)
     } else {
-      gifti_fname <- paste0(bname_cifti, ".func.gii")
+      gifti_fname <- paste0(bname_cifti, extn_gii)
     }
   }
   if (!keep) { write_dir <- tempdir() }
@@ -80,7 +84,10 @@ read_cifti_flat <- function(
     gifti_fname_original <- gifti_fname
     gifti_fname <- file.path(
       tempdir(), 
-      gsub("func\\.gii$", "selected_idx\\.func\\.gii", basename(gifti_fname_original))
+      gsub(
+        paste0(extn_gii2, "$"), paste0("\\.sel_idx", extn_gii2), 
+        basename(gifti_fname_original)
+      )
     )
 
     run_wb_cmd(paste(

--- a/R/read_xifti2.R
+++ b/R/read_xifti2.R
@@ -95,7 +95,10 @@ read_xifti2 <- function(
     if (!is.null(cortexL)) {
       x <- resample_gifti(
         cortexL, 
-        paste0("resamp", cifti_component_suffix("cortexL")),
+        paste0(
+          "resamp", 
+          cifti_component_suffix("cortexL", ifelse(grepl("label\\.gii$", cortexL), "label", "metric"))
+        ),
         hemisphere="left", resamp_res=resamp_res, 
         ROIcortex_original_fname=cortexL_mwall, 
         read_dir=read_dir, write_dir=tdir
@@ -107,7 +110,10 @@ read_xifti2 <- function(
     if (!is.null(cortexR)) {
       x <- resample_gifti(
         cortexR, 
-        paste0("resamp", cifti_component_suffix("cortexR")),
+        paste0(
+          "resamp", 
+          cifti_component_suffix("cortexR", ifelse(grepl("label\\.gii$", cortexR), "label", "metric"))
+        ),
         hemisphere="right", resamp_res=resamp_res, 
         ROIcortex_original_fname=cortexR_mwall, 
         read_dir=read_dir, write_dir=tdir
@@ -118,11 +124,7 @@ read_xifti2 <- function(
     ## Left surface.
     if (!is.null(surfL)) {
       surfL <- resample_gifti(
-        surfL, 
-        paste0(
-          "surf_resamp", 
-          gsub("func", "surf", cifti_component_suffix("cortexL"))
-        ),
+        surfL, paste0("resamp", cifti_component_suffix("cortexL", "surf")),
         hemisphere="left", file_type="surf", resamp_res=resamp_res,
         read_dir=read_dir, write_dir=tdir
       )
@@ -131,12 +133,8 @@ read_xifti2 <- function(
     ## Right surface.
     if (!is.null(surfR)) {
       surfR <- resample_gifti(
-        surfR, 
-        paste0(
-          "surf_resamp", 
-          gsub("func", "surf", cifti_component_suffix("cortexR"))
-        ),
-        hemisphere="left", file_type="surf", resamp_res=resamp_res,
+        surfR, paste0("resamp", cifti_component_suffix("cortexR", "surf")),
+        hemisphere="right", file_type="surf", resamp_res=resamp_res,
         read_dir=read_dir, write_dir=tdir
       )
     }

--- a/R/read_xifti2.R
+++ b/R/read_xifti2.R
@@ -97,7 +97,7 @@ read_xifti2 <- function(
         cortexL, 
         paste0(
           "resamp", 
-          cifti_component_suffix("cortexL", ifelse(grepl("label\\.gii$", cortexL), "label", "metric"))
+          cifti_component_suffix("cortexL", ifelse(grepl("label\\.gii$", cortexL), "label", "func"))
         ),
         hemisphere="left", resamp_res=resamp_res, 
         ROIcortex_original_fname=cortexL_mwall, 
@@ -112,7 +112,7 @@ read_xifti2 <- function(
         cortexR, 
         paste0(
           "resamp", 
-          cifti_component_suffix("cortexR", ifelse(grepl("label\\.gii$", cortexR), "label", "metric"))
+          cifti_component_suffix("cortexR", ifelse(grepl("label\\.gii$", cortexR), "label", "func"))
         ),
         hemisphere="right", resamp_res=resamp_res, 
         ROIcortex_original_fname=cortexR_mwall, 

--- a/R/read_xifti2.R
+++ b/R/read_xifti2.R
@@ -125,7 +125,7 @@ read_xifti2 <- function(
     if (!is.null(surfL)) {
       surfL <- resample_gifti(
         surfL, paste0("resamp", cifti_component_suffix("cortexL", "surf")),
-        hemisphere="left", file_type="surf", resamp_res=resamp_res,
+        hemisphere="left", file_type="surface", resamp_res=resamp_res,
         read_dir=read_dir, write_dir=tdir
       )
     }
@@ -134,7 +134,7 @@ read_xifti2 <- function(
     if (!is.null(surfR)) {
       surfR <- resample_gifti(
         surfR, paste0("resamp", cifti_component_suffix("cortexR", "surf")),
-        hemisphere="right", file_type="surf", resamp_res=resamp_res,
+        hemisphere="right", file_type="surface", resamp_res=resamp_res,
         read_dir=read_dir, write_dir=tdir
       )
     }

--- a/R/read_xifti2.R
+++ b/R/read_xifti2.R
@@ -119,7 +119,10 @@ read_xifti2 <- function(
     if (!is.null(surfL)) {
       surfL <- resample_gifti(
         surfL, 
-        paste0("surf_resamp", cifti_component_suffix("cortexL")),
+        paste0(
+          "surf_resamp", 
+          gsub("func", "surf", cifti_component_suffix("cortexL"))
+        ),
         hemisphere="left", file_type="surf", resamp_res=resamp_res,
         read_dir=read_dir, write_dir=tdir
       )
@@ -129,7 +132,10 @@ read_xifti2 <- function(
     if (!is.null(surfR)) {
       surfR <- resample_gifti(
         surfR, 
-        paste0("surf_resamp", cifti_component_suffix("cortexR")),
+        paste0(
+          "surf_resamp", 
+          gsub("func", "surf", cifti_component_suffix("cortexR"))
+        ),
         hemisphere="left", file_type="surf", resamp_res=resamp_res,
         read_dir=read_dir, write_dir=tdir
       )

--- a/R/resample_cifti_components.R
+++ b/R/resample_cifti_components.R
@@ -178,7 +178,7 @@ resample_cifti_components <- function(
           )
         )
       }
-      file_type <- ifelse(grepl(".label.gii", original_fnames[[lab]], fixed=TRUE), "label", "func")
+      file_type <- ifelse(grepl(".label.gii", original_fnames[[lab]], fixed=TRUE), "label", "metric")
       do.call(resample_gifti, c(resample_kwargs, list(file_type=file_type)))
     
     # Resample surfaces.

--- a/R/resample_cifti_components.R
+++ b/R/resample_cifti_components.R
@@ -178,7 +178,7 @@ resample_cifti_components <- function(
           )
         )
       }
-      file_type <- ifelse(grepl(".label.gii", original_fnames[[lab]], fixed=TRUE), "label", "metric")
+      file_type <- ifelse(grepl(".label.gii", original_fnames[[lab]], fixed=TRUE), "label", "func")
       do.call(resample_gifti, c(resample_kwargs, list(file_type=file_type)))
     
     # Resample surfaces.

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -26,3 +26,7 @@ Passes all the tests in `tests/run_ciftiTools_tests.R`
 ## Submission revision
 
 The previous submission was rejected because the tarball was over 5 MB. It has been reduced to 3.25 MB.
+
+## Submission revision 2
+
+The previous submission (0.4.1) was cancelled manually.

--- a/man/read_cifti_flat.Rd
+++ b/man/read_cifti_flat.Rd
@@ -20,7 +20,8 @@ and then reading it in. Should the GIFTI file be kept? If \code{FALSE}
 (default), write it in a temporary directory regardless of \code{write_dir}.}
 
 \item{gifti_fname}{File path of GIFTI-format data to save the CIFTI as.
-Default: the CIFTI_fname but with the extension replaced with "flat.gii".}
+Should end with ".func.gii". Default: the CIFTI_fname but with the extension
+replaced with ".func.gii".}
 
 \item{idx}{Numeric vector indicating the data indices (columns) to read. If
 \code{NULL} (default), read in all the data. Must be a subset of the indices

--- a/tests/testthat/test-misc.R
+++ b/tests/testthat/test-misc.R
@@ -179,10 +179,10 @@ test_that("Miscellaneous functions are working", {
     if (!grepl("dlabel", cii_fname)) {
       # Smooth metric GIFTI
       fnames_sep <- separate_cifti(cii_fname, write_dir=tdir)
-      smooth_gifti(fnames_sep[1], file.path(tdir, "sm.metric.gii"), hemisphere="left")
+      smooth_gifti(fnames_sep[1], file.path(tdir, "sm.func.gii"), hemisphere="left")
       smg1 <- gifti::readgii(
         smooth_gifti(
-          fnames_sep[3], file.path(tdir, "sm.metric.gii"),
+          fnames_sep[3], file.path(tdir, "sm.func.gii"),
           ROI_fname=fnames_sep[4], hemisphere="right"
         )
       )

--- a/vignettes/ciftiTools_vignette.Rmd
+++ b/vignettes/ciftiTools_vignette.Rmd
@@ -36,7 +36,7 @@ library(ciftiTools)
 Next, we indicate where to find the Connectome Workbench. This can be the full path to the Connectome Workbench executable file, or the path to its containing folder, in which case `ciftiTools` will locate the full path. Here, we will use the latter:
 
 ```{r}
-# Replace '/Applications/workbench' with the actual path to 
+# Replace '../../workbench' with the actual path to 
 #   the Connectome Workbench folder on your computer.
 #   If successful, the full path to the Workbench executable will be printed.
 ciftiTools.setOption('wb_path', '../../workbench')


### PR DESCRIPTION
    Add idx argument to read_xifti and similar functions, to conserve memory if only some columns are being read in. It will be faster for reading in a small number of columns, but slower for reading in a large subset.
    Add ... argument to transform_xifti
    Add apply_xifti which works similar to the base function apply
    The default surface is now less inflated, so it looks more like a brain
    Two other surfaces are available via the function load_surf
    Schaefer and Yeo parcellations are available via the function load_parc
    demo_files() is now ciftiTools.files()
    Rename unmask_vol to unmask_subcortex
    Add resamp_res argument to read_surf
    Resample surface in add_surf if necessary